### PR TITLE
Add the StartupWMClass to the app launcher

### DIFF
--- a/com.mattermost.Desktop.desktop
+++ b/com.mattermost.Desktop.desktop
@@ -5,5 +5,6 @@ Exec=mattermost-flatpak
 Terminal=false
 Type=Application
 Icon=com.mattermost.Desktop
+StartupWMClass=Mattermost
 Categories=Network;InstantMessaging;
 


### PR DESCRIPTION
This should fix the app icon showing up double in various docks/launchers.