### PR TITLE
Wayland and x-checker-data

### DIFF
--- a/com.mattermost.Desktop.json
+++ b/com.mattermost.Desktop.json
@@ -10,6 +10,7 @@
     "finish-args": [
         "--share=ipc",
         "--socket=x11",
+        "--socket=wayland",
         "--socket=pulseaudio",
         "--share=network",
         "--device=dri",

--- a/com.mattermost.Desktop.json
+++ b/com.mattermost.Desktop.json
@@ -47,6 +47,12 @@
                     "only-arches": ["x86_64"],
                     "url": "https://releases.mattermost.com/desktop/4.7.0/mattermost-desktop-4.7.0-linux-x64.tar.gz",
                     "sha256": "9bde569a8cdc49851a8bc879f741272f03984477166c46034cf7ed59a7ceeb9c",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://docs.mattermost.com/install/desktop.html",
+                        "version-pattern": "64-bit systems: mattermost-desktop-([\\d\\.-]+)-linux-x64.tar.gz",
+                        "url-pattern": "https://releases.mattermost.com/desktop/([\\d\\.-]+)/mattermost-desktop-([\\d\\.-]+)-linux-x64.tar.gz"
+                    },
                     "dest": "main"
                 },
                 {
@@ -54,6 +60,12 @@
                     "only-arches": ["i386"],
                     "url": "https://releases.mattermost.com/desktop/4.7.0/mattermost-desktop-4.7.0-linux-ia32.tar.gz",
                     "sha256": "8329f6ae2efcc07592f4fcf917163de85c08b798bee223ffdc471a4a1424ebe0",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://docs.mattermost.com/install/desktop.html",
+                        "version-pattern": "32-bit systems: mattermost-desktop-([\\d\\.-]+)-linux-ia32.tar.gz",
+                        "url-pattern": "https://releases.mattermost.com/desktop/([\\d\\.-]+)/mattermost-desktop-([\\d\\.-]+)-linux-ia32.tar.gz"
+                    },
                     "dest": "main"
                 },
                 {
@@ -71,7 +83,13 @@
                 {
                     "type": "file",
                     "url": "https://github.com/mattermost/desktop/archive/v4.7.0.tar.gz",
-                    "sha256": "f327d8560bebeb2075c7369898c3ed6c2d11be952a44853822a663ba42144055"
+                    "sha256": "f327d8560bebeb2075c7369898c3ed6c2d11be952a44853822a663ba42144055",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://docs.mattermost.com/install/desktop.html",
+                        "version-pattern": "64-bit systems: mattermost-desktop-([\\d\\.-]+)-linux-x64.tar.gz",
+                        "url-pattern": "https://github.com/mattermost/desktop/archive/v([\\d\\.-]+).tar.gz"
+                    }
                 }
             ]
      


### PR DESCRIPTION
You should be able to run this in native Wayland with `flatpak run com.mattermost.Desktop --enable-features=UseOzonePlatform --ozone-platform=wayland`. Note the window decorations will be missing on GNOME until https://github.com/electron/electron/pull/29618 is merged. This doesn't pass those flags by default, just makes them usable out of the box for those who want them.

x-checker-data should auto open PRs when Mattermost releases updates. See https://github.com/flathub/flatpak-external-data-checker for more info.
