### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/com.mattermost.Desktop.json
+++ b/com.mattermost.Desktop.json
@@ -13,7 +13,6 @@
         "--socket=wayland",
         "--socket=pulseaudio",
         "--socket=pcsc",
-        "--own-name=org.kde.*",
         "--share=network",
         "--device=all",
         "--filesystem=home",


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 26.1.0
https://github.com/mattermost/desktop/blob/4f266a367c6d69bbb0886df1880d77607804a207/package.json#L171