### PR TITLE
Update mattermost-desktop module

### DIFF
--- a/com.mattermost.Desktop.appdata.xml
+++ b/com.mattermost.Desktop.appdata.xml
@@ -33,8 +33,11 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="5.8.1" date="2024-06-13">
+    <release version="5.9.0-rc.1" date="2024-07-19">
       <description></description>
+    </release>
+    <release version="5.8.1" date="2024-06-13">
+      <description/>
     </release>
     <release version="5.8.1~rc1" date="2024-06-10">
       <description/>

--- a/com.mattermost.Desktop.json
+++ b/com.mattermost.Desktop.json
@@ -49,8 +49,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://releases.mattermost.com/desktop/5.8.1/mattermost-desktop-5.8.1-linux-x64.tar.gz",
-                    "sha256": "56e60717900b75bb0ac4123bc3952172a2982d5f011d99dc5920deb82cbf496d",
+                    "url": "https://releases.mattermost.com/desktop/5.9.0-rc.1/mattermost-desktop-5.9.0-rc.1-linux-x64.tar.gz",
+                    "sha256": "75509bf748319ff4d65a49a56262ceb40e690d369626f1ca3d7fc8853f73960d",
                     "x-checker-data": {
                         "is-main-source": true,
                         "type": "anitya",
@@ -90,8 +90,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/mattermost/desktop/archive/v5.8.1.tar.gz",
-                    "sha256": "8972c89568676ccf2903c45e255865e88583f27f3c2d67b2bcc5d9f381092658",
+                    "url": "https://github.com/mattermost/desktop/archive/v5.9.0-rc.1.tar.gz",
+                    "sha256": "7d2ce7fd3bc485dc81d23f29a3f6d872bd4782d9b04c016bbcc25dae9ece223e",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 215074,


### PR DESCRIPTION
mattermost-desktop: Update mattermost-desktop-5.8.1-linux-x64.tar.gz to 5.9.0-rc.1
mattermost-desktop: Update v5.8.1.tar.gz to 5.9.0-rc.1